### PR TITLE
Add missing `c` in `phpc.social` Mastodon instance domain.

### DIFF
--- a/views/get.php
+++ b/views/get.php
@@ -72,7 +72,7 @@
                         <h2>Follow Us!</h2>
 
                         <div class="block">
-                            <img src="img/mastodon.svg" width="64" alt="" style="float: left"> Follow us on Mastodon: <a href="https://phpc.social/@dokuwiki" target="_blank">@dokuwiki@php.social</a>
+                            <img src="img/mastodon.svg" width="64" alt="" style="float: left"> Follow us on Mastodon: <a href="https://phpc.social/@dokuwiki" target="_blank">@dokuwiki@phpc.social</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This adds the missing `c` in the `phpc.social` Mastodon instance domain to the handle. (The actual link was correct but not the text so copying it to follow on my own instance didn't work)